### PR TITLE
removed required: true from area key in recipe schema as stopping adi…

### DIFF
--- a/service/schemas/recipe.js
+++ b/service/schemas/recipe.js
@@ -45,7 +45,6 @@ const recipeSchema = new Schema(
     },
     area: {
       type: String,
-      required: true,
     },
     instructions: {
       type: String,


### PR DESCRIPTION
mala update to recipe schema - usunelam required: true z "area" bo wlasny przepis nie ma takiego pola wiec nie moze byc jako wymagane bo nie przechodzi. area jest tylko w tych globalnych przepisach a schema jest wspolna, mam nadzieje ze to ok